### PR TITLE
security: remove hardcoded credentials from test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,6 +423,8 @@ test_*.py
 *_test.py
 test_*.js
 test_*.ts
+# Ignore ad-hoc root-level test shell scripts to prevent accidental credential leaks
+/test_*.sh
 
 # Backup files
 *.bak

--- a/scripts/tests/test_security.sh
+++ b/scripts/tests/test_security.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
+# Credentials are read from environment variables to avoid hardcoding secrets.
+# Set TEST_USERNAME and TEST_PASSWORD before running this script.
+# Example: export TEST_USERNAME=testuser TEST_PASSWORD=yourpassword
+TEST_USERNAME="${TEST_USERNAME:-testuser}"
+TEST_PASSWORD="${TEST_PASSWORD:?ERROR: TEST_PASSWORD environment variable must be set}"
 echo "=== Testing Security Features ==="
 echo ""
 
 # 1. Test login and get access token
-echo "1. Testing Login with testuser..."
+echo "1. Testing Login with ${TEST_USERNAME}..."
 LOGIN_RESPONSE=$(curl -s -X POST "http://localhost:8000/api/auth/login" \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=testuser&password=testpass123")
+  -d "username=${TEST_USERNAME}&password=${TEST_PASSWORD}")
 
 ACCESS_TOKEN=$(echo $LOGIN_RESPONSE | python3 -c "import sys, json; print(json.load(sys.stdin).get('access_token', ''))" 2>/dev/null)
 
@@ -38,7 +43,7 @@ echo "   Starting MFA enrollment..."
 MFA_RESPONSE=$(curl -s -X POST "http://localhost:8000/api/mfa/enroll" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"password": "testpass123"}')
+  -d "{\"password\": \"${TEST_PASSWORD}\"}")
 
 echo "   Response (truncated for readability):"
 echo $MFA_RESPONSE | python3 -c "import sys, json; data = json.load(sys.stdin); print(json.dumps({'secret': data.get('secret', 'N/A'), 'qr_code_url': 'data:image/png;base64,...' if 'qr_code_url' in data else 'N/A', 'backup_codes_count': len(data.get('backup_codes', []))}, indent=2))"


### PR DESCRIPTION
- Replace hardcoded password in scripts/tests/test_security.sh with TEST_USERNAME / TEST_PASSWORD env vars (fails fast if unset)
- Add /test_*.sh to .gitignore to prevent root-level ad-hoc test scripts from being accidentally committed
- (History already rewritten: admin123 redacted from test_add_category.sh via git-filter-repo and force-pushed to all branches)