### PR TITLE
fix: remove client IP from session fingerprint for reverse-proxy

### DIFF
--- a/portfolio-backend/app/core/secure_cookies.py
+++ b/portfolio-backend/app/core/secure_cookies.py
@@ -273,10 +273,11 @@ class SecureCookieManager:
             Fingerprint string
         """
         user_agent = request.headers.get("user-agent", "unknown")
-        client_ip = request.client.host if request.client else "unknown"
-        
-        # Combine user-agent and IP for fingerprint
-        fingerprint = f"{user_agent}|{client_ip}"
+
+        # Use only user-agent for fingerprint — not client IP.
+        # Behind a reverse proxy the IP seen by uvicorn is the proxy's address
+        # and can vary between workers or requests, causing false-positive mismatches.
+        fingerprint = user_agent
         return fingerprint
     
     @classmethod


### PR DESCRIPTION
…atibility

Behind nginx (or any reverse proxy) request.client.host is the proxy's address, which can differ between uvicorn workers and nginx worker processes — causing a fingerprint mismatch on the very first API call after login and an immediate 401.

Use only the User-Agent for fingerprinting. This still detects stolen tokens (different device/browser) while avoiding false positives from proxy-induced IP variation.