### PR TITLE
fix: align JWT signing algorithm with settings.ALGORITHM in auth/jwt.py

### DIFF
--- a/portfolio-backend/app/auth/jwt.py
+++ b/portfolio-backend/app/auth/jwt.py
@@ -2,14 +2,22 @@ from datetime import datetime, timedelta
 import jwt
 from app.core.config import settings
 
+
+def _signing_key() -> str:
+    """Return the key used to sign tokens (respects ALGORITHM setting)."""
+    if settings.ALGORITHM == "RS256":
+        return settings.get_private_key()
+    return settings.SECRET_KEY
+
+
 def create_access_token(data: dict, expires_delta: timedelta = None):
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta if expires_delta else timedelta(minutes=15))
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm="HS256")
+    return jwt.encode(to_encode, _signing_key(), algorithm=settings.ALGORITHM)
 
 def create_refresh_token(data: dict, expires_delta: timedelta = None):
     to_encode = data.copy()
     expire = datetime.utcnow() + (expires_delta if expires_delta else timedelta(days=1))
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm="HS256")
+    return jwt.encode(to_encode, _signing_key(), algorithm=settings.ALGORITHM)


### PR DESCRIPTION
The module was hardcoding algorithm="HS256" while deps.py verifies with settings.ALGORITHM. When the .env has ALGORITHM=RS256, the token is signed with HS256 but verified expecting RS256, causing:
  "JWT validation error: The specified alg value is not allowed"

Now uses the same algorithm and key selection as the rest of the codebase.