### PR TITLE
fix: inject production API env vars into frontend CI builds

### DIFF
--- a/.github/workflows/deploy-frontend-vps.yml
+++ b/.github/workflows/deploy-frontend-vps.yml
@@ -89,6 +89,7 @@ jobs:
         working-directory: website
         env:
           CI: "false"
+          REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL }}
         run: npm run build
 
       - name: Package artifact

--- a/.github/workflows/deploy-full-stack-vps.yml
+++ b/.github/workflows/deploy-full-stack-vps.yml
@@ -93,6 +93,7 @@ jobs:
         working-directory: website
         env:
           CI: "false"
+          REACT_APP_API_URL: ${{ secrets.REACT_APP_API_URL }}
         run: npm run build
 
       - name: Package artifact


### PR DESCRIPTION
Both deploy-frontend-vps and deploy-full-stack-vps workflows now pass REACT_APP_SERVER_HOSTNAME/PORT/PROTOCOL (backend-ui) and REACT_APP_API_URL (website) during npm build so localhost:8000 is not baked into bundles.