### PR TITLE
fix: pass REACT_APP_WEBSITE_URL to backend-ui CI build

### DIFF
--- a/.github/workflows/deploy-frontend-vps.yml
+++ b/.github/workflows/deploy-frontend-vps.yml
@@ -50,6 +50,7 @@ jobs:
           REACT_APP_SERVER_HOSTNAME: ${{ secrets.REACT_APP_SERVER_HOSTNAME }}
           REACT_APP_SERVER_PORT: ${{ secrets.REACT_APP_SERVER_PORT }}
           REACT_APP_SERVER_PROTOCOL: ${{ secrets.REACT_APP_SERVER_PROTOCOL }}
+          REACT_APP_WEBSITE_URL: ${{ secrets.REACT_APP_WEBSITE_URL }}
         run: npm run build
 
       - name: Package artifact

--- a/.github/workflows/deploy-full-stack-vps.yml
+++ b/.github/workflows/deploy-full-stack-vps.yml
@@ -54,6 +54,7 @@ jobs:
           REACT_APP_SERVER_HOSTNAME: ${{ secrets.REACT_APP_SERVER_HOSTNAME }}
           REACT_APP_SERVER_PORT: ${{ secrets.REACT_APP_SERVER_PORT }}
           REACT_APP_SERVER_PROTOCOL: ${{ secrets.REACT_APP_SERVER_PROTOCOL }}
+          REACT_APP_WEBSITE_URL: ${{ secrets.REACT_APP_WEBSITE_URL }}
         run: npm run build
 
       - name: Package artifact


### PR DESCRIPTION
Without this secret the edit-portfolio-website link redirects to localhost:3000 instead of the production website URL.